### PR TITLE
fix dockerfile: entry point

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ WORKDIR /code
 
 RUN composer install --prefer-dist --no-interaction
 
-CMD php ./src/App.php run /data
+CMD php ./src/run.php run /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ WORKDIR /code
 
 RUN composer install --prefer-dist --no-interaction
 
-CMD php ./src/app.php run /data
+CMD php ./src/App.php run /data


### PR DESCRIPTION
Fixes #8 

pustim komponentu a skonci to na chybe `Application error: Could not open input file: ./src/app.php`
V zlozke src je subor `App.php` a nie `app.php` -> podla toho upravujem entrypoint dockerfile.
