### PR TITLE
set default value of backendUrl to empty string

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -25,7 +25,7 @@ class Config extends BaseConfig
 
     public function getProjectBackendUrl(): string
     {
-        return $this->getValue(['parameters', 'project', 'backendUrl'], null);
+        return $this->getValue(['parameters', 'project', 'backendUrl'], '');
     }
 
     public function getTables(): array


### PR DESCRIPTION
podla https://github.com/keboola/php-component/blob/master/src/Config/BaseConfig.php#L79 default hodnota getValue nemoze byt null(inac to hodi exception). Tato uprava pouzije prazdny string ako default hodnotu pre project backendUrl parameter.