### PR TITLE
fix filename resolving: fallback to 'source' if 'destation' is not present in im

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -100,13 +100,16 @@ class App
                 $config->getTables()[$tableId],
                 $projectDefinition
             );
-
+            $fileName = $table['source']; // aka $tableId
+            if (isset($table['destination'])) {
+                $fileName = $table['destination'];
+            }
             $tmpDir = $this->temp->getTmpFolder() . '/' . $tableId;
             mkdir($tmpDir);
             $upload = new Upload($this->gdClient, $this->logger, $tmpDir);
 
             $upload->createSingleLoadManifest($tableDef);
-            $upload->createCsv("$inputPath/{$table['destination']}", $tableDef);
+            $upload->createCsv("$inputPath/{$fileName}", $tableDef);
             $upload->upload($config->getProjectPid(), $tableId);
         }
     }


### PR DESCRIPTION
UI generuje input mapping iba so `source` property. Gooddata Writer ocaka `destination` parameter no podla dokumentacie neni uplne treba: ` If destination is not set, the CSV file will have the same name as the table (without adding .csv suffix).`
https://developers.keboola.com/extend/common-interface/config-file/#tables

Databasove writere to maju podobne, tj ui generuje IM so `source`: tableId a docker komponenty si to beru odtial.

Tato uprava berie `destination` ak existuje a fallbackuje na `source`.