### PR TITLE
fix: read model to configuration

### DIFF
--- a/src/ConfigDefinition.php
+++ b/src/ConfigDefinition.php
@@ -39,6 +39,7 @@ class ConfigDefinition extends BaseConfigDefinition
                         ->scalarNode('title')->isRequired()->cannotBeEmpty()->end()
                         ->scalarNode('identifier')->end()
                         ->booleanNode('disabled')->end()
+                        ->scalarNode('anchorIdentifier')->end()
                         ->arrayNode('columns')->isRequired()->useAttributeAsKey('name')
                             ->arrayPrototype()
                                 ->children()

--- a/src/ModelReader.php
+++ b/src/ModelReader.php
@@ -44,10 +44,6 @@ class ModelReader
                         'tableId' => $bucket . '.' . Identifiers::getIdentifier($dataSet['dataset']['title']),
                         'identifier' => $dataSet['dataset']['identifier'],
                         'title' => $dataSet['dataset']['title'],
-                        'export' => 1,
-                        'isExported' => 1,
-                        'incrementalLoad' => 0,
-                        'ignoreFilter' => null,
                         'columns' => [],
                         'grain' => [],
                     ];
@@ -130,7 +126,6 @@ class ModelReader
                     'identifier' => $dimension['dateDimension']['name'],
                     'includeTime' => null,
                     'template' => $template,
-                    'isExported' => 1,
                 ];
             }
         }
@@ -261,6 +256,20 @@ class ModelReader
                 $columns[$columnName] = $c;
             }
             $d['columns'] = $columns;
+        }
+
+        // Put names of dimensions to keys
+        $dimensions = [];
+        foreach ($result['dateDimensions'] as $dimension) {
+            $name = $dimension['name'];
+            unset($dimension['name']);
+            $dimensions[$name] = $dimension;
+        }
+        $result['dateDimensions'] = $dimensions;
+
+        // Remove tableId from datasets
+        foreach ($result['dataSets'] as &$dataSet) {
+            unset($dataSet['tableId']);
         }
 
         return $result;

--- a/tests/functional/DatadirTest.php
+++ b/tests/functional/DatadirTest.php
@@ -87,24 +87,17 @@ class DatadirTest extends AbstractDatadirTestCase
             __DIR__ . '/read-model/source/data',
             0,
             '{
-    "dimensions": [
-        {
-            "name": "product date",
+    "dimensions": {
+        "product date": {
             "identifier": "productdate",
             "includeTime": 1,
-            "template": "GOODDATA",
-            "isExported": 1
+            "template": "GOODDATA"
         }
-    ],
+    },
     "tables": {
         "in.c-gd-model.categories": {
-            "tableId": "in.c-gd-model.categories",
             "identifier": "dataset.outcmaincategories",
             "title": "categories",
-            "export": 1,
-            "isExported": 1,
-            "incrementalLoad": 0,
-            "ignoreFilter": null,
             "columns": {
                 "cp_id": {
                     "identifier": "attr.outcmaincategories.id",
@@ -133,13 +126,8 @@ class DatadirTest extends AbstractDatadirTestCase
             "grain": []
         },
         "in.c-gd-model.products": {
-            "tableId": "in.c-gd-model.products",
             "identifier": "dataset.outcmainproducts",
             "title": "products",
-            "export": 1,
-            "isExported": 1,
-            "incrementalLoad": 0,
-            "ignoreFilter": null,
             "columns": {
                 "cp_id": {
                     "identifier": "attr.outcmainproducts.id",
@@ -183,13 +171,8 @@ class DatadirTest extends AbstractDatadirTestCase
             "grain": []
         },
         "in.c-gd-model.productsgrain": {
-            "tableId": "in.c-gd-model.productsgrain",
             "identifier": "dataset.outcmainproductsgrain",
             "title": "products-grain",
-            "export": 1,
-            "isExported": 1,
-            "incrementalLoad": 0,
-            "ignoreFilter": null,
             "columns": {
                 "a_id": {
                     "identifier": "attr.outcmainproductsgrain.id",

--- a/tests/phpunit/AppTest.php
+++ b/tests/phpunit/AppTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Keboola\GoodDataWriter\Test;
 
+use Keboola\Component\Config\BaseConfig;
 use Keboola\Component\Logger;
 use Keboola\GoodData\Client;
 use Keboola\GoodDataWriter\App;
@@ -14,6 +15,7 @@ use Keboola\StorageApi\Components;
 use Keboola\StorageApi\Options\Components\Configuration;
 use Keboola\Temp\Temp;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 /**
  * @covers \Keboola\GoodDataWriter\App
@@ -172,7 +174,7 @@ class AppTest extends TestCase
         $resConfig = $config['configuration']['parameters'];
         $this->assertArrayHasKey('dimensions', $resConfig);
         $this->assertCount(1, $resConfig['dimensions']);
-        $this->assertEquals('productdate', $resConfig['dimensions'][0]['identifier']);
+        $this->assertEquals('productdate', current($resConfig['dimensions'])['identifier']);
         $this->assertArrayHasKey('tables', $resConfig);
         $this->assertCount(3, $resConfig['tables']);
         $this->assertArrayHasKey('in.c-data.categories', $resConfig['tables']);
@@ -182,6 +184,12 @@ class AppTest extends TestCase
         $this->assertArrayHasKey('input', $config['configuration']['storage']);
         $this->assertArrayHasKey('tables', $config['configuration']['storage']['input']);
         $this->assertCount(3, $config['configuration']['storage']['input']['tables']);
+
+        try {
+            $config = new BaseConfig($config, new ConfigDefinition());
+        } catch (InvalidConfigurationException $e) {
+            $this->fail('Check of model read against ConfigDefinition failed');
+        }
 
         $components->deleteConfiguration('keboola.gooddata-writer', $configId);
         $client->dropBucket('in.c-data', ['force' => true]);


### PR DESCRIPTION
Tak to vypadá, že jsem tam zapomněl dost starý konfigurace, která neprojde přes `ConfigDefinition`. Ale celej ten kód ModelReaderu je teda docela hororovej. A chtěl by spíš napsat znovu, s čímž ale čas trávit nechceme. ;o/

Takže jsem z datasetů i dimenzí odstranil pár nepoužívaných atributů a názvy se přesunuly z atributů do klíčů asociativního pole.