### PR TITLE
Report access to project error as user error (COM-120)

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -49,7 +49,8 @@ class App
             try {
                 $this->gdProvisioning->addUserToProject($config->getUserLogin(), $config->getProjectPid());
             } catch (\GuzzleHttp\Exception\ClientException $e) {
-                throw new UserException('Access to the project cannot be acquired: ' . (string) $e->getResponse()->getBody());
+                throw new UserException('Access to the project cannot be acquired: '
+                    . (string) $e->getResponse()->getBody());
             }
             $this->logger->info("Service account for data loads ({$config->getUserLogin()}) added to "
                 . 'the project using GoodData Provisioning');

--- a/src/App.php
+++ b/src/App.php
@@ -46,7 +46,11 @@ class App
             if (!getenv('KBC_TOKEN')) {
                 throw new \Exception('KBC Token is missing from the environment');
             }
-            $this->gdProvisioning->addUserToProject($config->getUserLogin(), $config->getProjectPid());
+            try {
+                $this->gdProvisioning->addUserToProject($config->getUserLogin(), $config->getProjectPid());
+            } catch (\GuzzleHttp\Exception\ClientException $e) {
+                throw new UserException('Access to the project cannot be acquired: ' . (string) $e->getResponse()->getBody());
+            }
             $this->logger->info("Service account for data loads ({$config->getUserLogin()}) added to "
                 . 'the project using GoodData Provisioning');
         }


### PR DESCRIPTION
Řeší: https://connection.eu-central-1.keboola.com/admin/utils/logs?file=2020/01/25/17/2020-01-25-17-52-11-5e2c723ba1f63-exception. Provisioning nemůže přidat usera do toho projektu, protože z něj nejspíš ručně odstranili našeho doménovýho admina. Což nemají dělat. ;o)

Selhání na `\GuzzleHttp\Exception\ClientException` se teda nareportuje jako user error. Víc bych tu chybu v kódu nezkoumal. Bohužel to nejspíš nejde moc jednoduše namockovat v testech, tak bych byl pro se s tím takto spokojit. ;o)